### PR TITLE
eliminado parrafo articulo.html

### DIFF
--- a/articulo.html
+++ b/articulo.html
@@ -47,7 +47,6 @@
 				</header>
 				<p>Git es un software de control de versiones diseñado por Linus Torvalds, pensando en la eficiencia, la confiabilidad y compatibilidad del mantenimiento de versiones de aplicaciones cuando estas tienen un gran número de archivos de código fuente. Su propósito es llevar registro de los cambios en archivos de computadora incluyendo coordinar el trabajo que varias personas realizan sobre archivos. </p>
 				<p>Al principio, Git se pensó como un motor de bajo nivel sobre el cual otros pudieran escribir la interfaz de usuario o front end como Cogito o StGIT. Sin embargo, Git se ha convertido desde entonces en un sistema de control de versiones con funcionalidad plena. Hay algunos proyectos de mucha relevancia que ya usan Git, en particular, el grupo de programación del núcleo Linux. </p>
-				<p>El mantenimiento del softsware Git está actualmente (2009) supervisado por Junio Hamano, quien recibe contribuciones al código de alrededor de 280 programadores. En cuanto a derechos de autor, Git es un software libre distribuible bajo los términos del a versión 2 de la Licencia Pública General de GNU.</p>
 			</div>
 		</div>
 	</section>


### PR DESCRIPTION
Se ha eliminado el tercer párrafo del artículo de GIT en articulo.html porque no es del todo correcto.